### PR TITLE
Add bitmaps sub-command to dump bitmaps from EBDT/CBDT tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "allsorts"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -39,11 +39,13 @@ dependencies = [
 name = "allsorts-tools"
 version = "0.3.0"
 dependencies = [
- "allsorts 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "allsorts 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "endio_bit 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -98,6 +100,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +120,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "endio_bit"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
@@ -138,6 +154,14 @@ dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "inflate"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -261,6 +285,17 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "png"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,7 +354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum alloc-no-stdlib 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5192ec435945d87bc2f70992b4d818154b5feede43c09fb7592146374eac90a6"
 "checksum alloc-stdlib 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
-"checksum allsorts 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e056029eaa48069752b2b85b511e42959f4ff55db7c23ed55db168eb66791acc"
+"checksum allsorts 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6481ad5a33dc9d81d5420eb03e8c9c187b58e1f5e3612fc646c02d33806360"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
@@ -328,11 +363,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+"checksum deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
+"checksum endio_bit 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd9fca1a239ae11a0e7ba44a936f565c22573009a9c2ab6237ff1811169bbf7a"
 "checksum flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ad3c5233c9a940c8719031b423d7e6c16af66e031cb0420b0896f5245bf181d3"
 "checksum gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee50908bc1beeac1f2902e0b4e0cd0d844e716f5ebdc6f0cfc1163fe5e10bcde"
 "checksum gumdrop_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
+"checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)" = "74dfca3d9957906e8d1e6a0b641dc9a59848e793f1da2165889fd4f62d10d79c"
@@ -347,6 +385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
+"checksum png 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef859a23054bbfee7811284275ae522f0434a3c8e7f4b74bd4a35ae7e1c4a283"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,10 @@ name = "allsorts"
 path = "src/main.rs"
 
 [dependencies]
-allsorts = "0.2.0"
+allsorts = "0.3.0"
 atty = "0.2.13"
+endio_bit = "0.1.0"
 encoding_rs = "0.8.16"
 gumdrop = "0.7.0"
 itertools = "0.8.0"
+png = "0.15.3"

--- a/README.md
+++ b/README.md
@@ -31,11 +31,45 @@ not rely on them for production workflows.
 
 Available tools:
 
+* `bitmaps` — dump bitmaps from bitmaps fonts
 * `dump` — dump font information
 * `has-table` — check if a font has a particular table
 * `shape` — apply shaping to glyphs from a font
 * `subset` — subset a font
 * `validate` — parse the supplied font, reporting any failures
+
+### `bitmaps`
+
+The `bitmaps` tool extracts bitmaps from fonts containing glyph bitmaps in
+either the `EBLC`/`EBDT` or `CBLC`/`CBDT` tables.
+
+`-o` is the path to the directory to write the bitmaps to. It will be created
+if it does not exist.
+
+The images are written out as PNGs in a sub-directory for each strike (size).
+The format is `{ppem_x}x{ppem_y}@{bit_depth}`, the files are named
+`{glyph_id}.png`:
+
+    terminus
+    ├── 12x12@1
+    │  ├── 0.png
+    │  ├── 1.png
+    │  ├── 2.png
+    │  ├── 3.png
+    │  ├── 4.png
+    │  ├── 5.png
+    │  ├── 6.png
+    │  ├── 7.png
+    ⋮  ⋮
+    ├── 14x14@1
+    │  ├── 0.png
+    ⋮  ⋮
+    └── 32x32@1
+    ⋮  ⋮
+
+#### Example
+
+    allorts bitmaps -o noto-color-emoji NotoColorEmoji.ttf
 
 ### `dump`
 
@@ -54,7 +88,7 @@ redirected to a file. E.g. `allsorts dump -t glyf > glyf.bin`
 
 `-l` option prints out all offsets in the `loca` table in the font.
 
-### Example
+#### Example
 
     $ allsorts dump noto-subset.otd | head
     TTF

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ not rely on them for production workflows.
 
 Available tools:
 
-* `bitmaps` — dump bitmaps from bitmaps fonts
+* `bitmaps` — dump bitmaps from bitmap fonts
 * `dump` — dump font information
 * `has-table` — check if a font has a particular table
 * `shape` — apply shaping to glyphs from a font
@@ -69,7 +69,7 @@ The format is `{ppem_x}x{ppem_y}@{bit_depth}`, the files are named
 
 #### Example
 
-    allorts bitmaps -o noto-color-emoji NotoColorEmoji.ttf
+    allsorts bitmaps -o noto-color-emoji NotoColorEmoji.ttf
 
 ### `dump`
 

--- a/src/bitmaps.rs
+++ b/src/bitmaps.rs
@@ -1,0 +1,199 @@
+use std::borrow::Borrow;
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::Path;
+use std::{fs, io};
+
+use endio_bit::BitReader;
+
+use allsorts::binary::read::ReadScope;
+use allsorts::bitmap::{self, BitDepth, BitmapSize, CBDTTable, CBLCTable, GlyphBitmapData};
+use allsorts::fontfile::FontFile;
+use allsorts::tables::FontTableProvider;
+use allsorts::tag::{self};
+
+use crate::cli::BitmapOpts;
+use crate::BoxError;
+
+pub fn main(opts: BitmapOpts) -> Result<i32, BoxError> {
+    let buffer = std::fs::read(&opts.font)?;
+    let scope = ReadScope::new(&buffer);
+    let font_file = scope.read::<FontFile>()?;
+    let table_provider = font_file.table_provider(opts.index)?;
+
+    let table = table_provider
+        .table_data(tag::CBLC)?
+        .or(table_provider.table_data(tag::EBLC)?)
+        .ok_or("font does not have CBLC or EBLC tables")?;
+    let scope = ReadScope::new(table.borrow());
+    let cblc = scope.read::<CBLCTable<'_>>().unwrap();
+    let table = table_provider
+        .table_data(tag::CBDT)?
+        .or(table_provider.table_data(tag::EBDT)?)
+        .ok_or("font does not have CBDT or EBDT tables")?;
+    let scope = ReadScope::new(table.borrow());
+    let cbdt = scope.read::<CBDTTable<'_>>().unwrap();
+
+    let output_path = Path::new(&opts.output);
+    if !output_path.exists() {
+        fs::create_dir(output_path)?;
+    }
+
+    for strike in cblc.bitmap_sizes.iter_res() {
+        let strike = strike?;
+        let strike_path = output_path.join(&format!(
+            "{}x{}@{}",
+            strike.ppem_x, strike.ppem_y, strike.bit_depth as u8
+        ));
+        if !strike_path.exists() {
+            fs::create_dir(&strike_path)?;
+        }
+        dump_bitmaps(strike, &strike_path, &cblc, &cbdt)?;
+    }
+
+    Ok(0)
+}
+
+fn dump_bitmaps<'a>(
+    strike: BitmapSize,
+    path: &Path,
+    cblc: &'a CBLCTable<'a>,
+    cbdt: &'a CBDTTable<'a>,
+) -> Result<(), BoxError> {
+    for glyph_id in strike.start_glyph_index..=strike.end_glyph_index {
+        if let Some(bitmap) =
+            bitmap::lookup(glyph_id, strike.ppem_x, BitDepth::ThirtyTwo, cblc, cbdt)?
+        {
+            let glyph_path = path.join(&format!("{}.png", glyph_id));
+            match bitmap {
+                (_, GlyphBitmapData::Format17 { data, .. })
+                | (_, GlyphBitmapData::Format18 { data, .. })
+                | (_, GlyphBitmapData::Format19 { data, .. }) => {
+                    // Already PNG, just write it out
+                    fs::write(&glyph_path, data)?;
+                }
+                (_, GlyphBitmapData::Format8 { components, .. })
+                | (_, GlyphBitmapData::Format9 { components, .. }) => {
+                    let ids = components
+                        .iter()
+                        .map(|component| component.glyph_id.to_string())
+                        .collect::<Vec<_>>();
+                    println!("glyph {} is comprised of {}", glyph_id, ids.join(", "))
+                }
+                (_, bitmap) => {
+                    // Convert to PNG and write out
+                    if bitmap.width() == 0 || bitmap.height() == 0 {
+                        println!(
+                            "glyph {} has 0 dimension: {}x{}",
+                            glyph_id,
+                            bitmap.width(),
+                            bitmap.height()
+                        );
+                        continue;
+                    }
+                    let file = File::create(&glyph_path)?;
+                    let w = BufWriter::new(file);
+                    let mut encoder =
+                        png::Encoder::new(w, u32::from(bitmap.width()), u32::from(bitmap.height()));
+                    encoder.set_color(if strike.bit_depth != BitDepth::ThirtyTwo {
+                        png::ColorType::Grayscale
+                    } else {
+                        png::ColorType::RGBA
+                    });
+                    let bit_depth = match strike.bit_depth {
+                        BitDepth::One => png::BitDepth::One,
+                        BitDepth::Two => png::BitDepth::Two,
+                        BitDepth::Four => png::BitDepth::Four,
+                        BitDepth::Eight | BitDepth::ThirtyTwo => png::BitDepth::Eight,
+                    };
+                    encoder.set_depth(bit_depth);
+                    let mut writer = encoder.write_header()?;
+                    write_image_data(&strike, &bitmap, &mut writer)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn write_image_data(
+    strike: &BitmapSize,
+    bitmap: &GlyphBitmapData,
+    writer: &mut png::Writer<BufWriter<File>>,
+) -> Result<(), BoxError> {
+    match bitmap {
+        // Format 1: small metrics, byte-aligned data.
+        GlyphBitmapData::Format1 { data, .. } => {
+            writer.write_image_data(data)?;
+        }
+        // Format 2: small metrics, bit-aligned data.
+        GlyphBitmapData::Format2 {
+            small_metrics,
+            data,
+        } => {
+            let image_data = unpack_bit_aligned_data(
+                strike.bit_depth,
+                small_metrics.width,
+                small_metrics.height,
+                data,
+            )?;
+            writer.write_image_data(&image_data)?;
+        }
+        // Format 5: metrics in EBLC, bit-aligned image data only.
+        GlyphBitmapData::Format5 { big_metrics, data } => {
+            let image_data = unpack_bit_aligned_data(
+                strike.bit_depth,
+                big_metrics.width,
+                big_metrics.height,
+                data,
+            )?;
+            writer.write_image_data(&image_data)?;
+        }
+        // Format 6: big metrics, byte-aligned data.
+        GlyphBitmapData::Format6 { .. } => unimplemented!("format 6 need a test font"),
+        // Format7: big metrics, bit-aligned data.
+        GlyphBitmapData::Format7 { data, big_metrics } => {
+            let image_data = unpack_bit_aligned_data(
+                strike.bit_depth,
+                big_metrics.width,
+                big_metrics.height,
+                data,
+            )?;
+            writer.write_image_data(&image_data)?;
+        }
+        _ => unreachable!("handled in dump_bitmaps"),
+    }
+
+    Ok(())
+}
+
+fn unpack_bit_aligned_data(
+    bit_depth: BitDepth,
+    width: u8,
+    height: u8,
+    data: &[u8],
+) -> io::Result<Vec<u8>> {
+    let bits_per_row = bit_depth as usize * usize::from(width);
+    let whole_bytes_per_row = bits_per_row >> 3;
+    let remaining_bits = (bits_per_row & 7) as u8;
+    let bytes_per_row = whole_bytes_per_row + if remaining_bits != 0 { 1 } else { 0 };
+
+    let mut offset = 0;
+    let mut image_data = vec![0u8; usize::from(height) * bytes_per_row];
+    let mut reader = BitReader::new(data);
+    for _ in 0..height {
+        // Read whole bytes, then the remainder
+        for byte in image_data[offset..(offset + whole_bytes_per_row)].iter_mut() {
+            *byte = reader.read_bits(8)?;
+        }
+        offset += whole_bytes_per_row;
+        if remaining_bits != 0 {
+            *image_data.get_mut(offset).unwrap() =
+                reader.read_bits(remaining_bits)? << (8 - remaining_bits);
+            offset += 1;
+        }
+    }
+
+    Ok(image_data)
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,9 @@ pub struct Cli {
 
 #[derive(Debug, Options)]
 pub enum Command {
+    #[options(help = "dump all bitmaps in EBDT/CBDT tables")]
+    Bitmaps(BitmapOpts),
+
     #[options(help = "dump font information")]
     Dump(DumpOpts),
 
@@ -25,6 +28,25 @@ pub enum Command {
 
     #[options(help = "apply shaping to glyphs from a font")]
     Shape(ShapeOpts),
+}
+
+#[derive(Debug, Options)]
+pub struct BitmapOpts {
+    #[options(help = "print help message")]
+    pub help: bool,
+
+    #[options(
+        help = "index of the font to dump (for TTC, WOFF2)",
+        meta = "INDEX",
+        default = "0"
+    )]
+    pub index: usize,
+
+    #[options(required, help = "path to directory to write to")]
+    pub output: String,
+
+    #[options(free, required, help = "path to font to dump")]
+    pub font: String,
 }
 
 #[derive(Debug, Options)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bitmaps;
 pub mod cli;
 pub mod dump;
 mod glyph;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,13 @@ use gumdrop::Options;
 use std::process;
 
 use allsorts_tools::cli::*;
-use allsorts_tools::{dump, has_table, shape, subset, validate};
+use allsorts_tools::{bitmaps, dump, has_table, shape, subset, validate};
 
 fn main() {
     let cli = Cli::parse_args_default_or_exit();
 
     let res = match cli.command {
+        Some(Command::Bitmaps(opts)) => bitmaps::main(opts),
         Some(Command::Dump(opts)) => dump::main(opts),
         Some(Command::HasTable(opts)) => has_table::main(opts),
         Some(Command::Shape(opts)) => shape::main(opts),


### PR DESCRIPTION
Adds a `bitmaps` sub-command for extracting bitmaps.

~~**Note:** this can't be merged until allsorts changes are merged and released.~~ — Done