### PR TITLE
Add --all option to subset to include all glyphs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,12 +116,11 @@ pub struct SubsetOpts {
     #[options(help = "print help message")]
     pub help: bool,
 
-    #[options(
-        required,
-        help = "subset the font to include glyphs from TEXT",
-        meta = "TEXT"
-    )]
-    pub text: String,
+    #[options(help = "subset the font to include glyphs from TEXT", meta = "TEXT")]
+    pub text: Option<String>,
+
+    #[options(help = "include all glyphs in the subset font")]
+    pub all: bool,
 
     #[options(
         help = "index of the font to dump (for TTC, WOFF2)",


### PR DESCRIPTION
This is handy when paired with the `validate` sub-command to validate that the output subset font can be parsed.