### PR TITLE
Rework shape tool to use FontDataImpl

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,6 +154,13 @@ pub struct ShapeOpts {
     #[options(required, help = "path to font file", meta = "PATH")]
     pub font: String,
 
+    #[options(
+        help = "index of the font to dump (for TTC, WOFF2)",
+        meta = "INDEX",
+        default = "0"
+    )]
+    pub index: usize,
+
     #[options(required, help = "script to shape", meta = "SCRIPT")]
     pub script: String,
 


### PR DESCRIPTION
I was sketching out some thoughts on the Allsorts API and noticed that the `shape` tool would be less concerned with low-level details if it used `FontDataImpl` so I changed it to use that.

Additionally this makes it gain support for shaping text using WOFF and WOFF2 fonts. I also allowed the font index to be specified on the CLI for TTC and WOFF2 font collections.