### PR TITLE
Add option to annotate glyph origin in generated SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ large repertoire of real world fonts.
 The `view` tool shapes the supplied text or list of codepoints according to the
 supplied font, language, and script. Then, it generates an SVG of the glyphs.
 
-`--annotate` will place a cross-hair at the origin of each glyph in the generated
+`--mark-origin` will place a cross-hair at the origin of each glyph in the generated
 SVG.
 
 #### Example Using Text

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The `dump` tool prints or extracts information from a font file.
 
 `allsorts dump path/to/font` prints out information about the font.
 
-`--name` includes the meta data contained in the `name` table in the output.
+`--name` includes the metadata contained in the `name` table in the output.
 
 `-c` can be used to print information about a CFF font or table not
 wrapped in a TrueType or OpenType container.
@@ -230,6 +230,9 @@ large repertoire of real world fonts.
 
 The `view` tool shapes the supplied text or list of codepoints according to the
 supplied font, language, and script. Then, it generates an SVG of the glyphs.
+
+`--annotate` will place a cross-hair at the origin of each glyph in the generated
+SVG.
 
 #### Example Using Text
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -273,8 +273,8 @@ pub struct ViewOpts {
     #[options(help = "language to shape", meta = "LANG")]
     pub lang: Option<String>,
 
-    #[options(help = "Annotate the origin of each glyph with a cross-hair", no_short)]
-    pub annotate: bool,
+    #[options(help = "Mark the origin of each glyph with a cross-hair", no_short)]
+    pub mark_origin: bool,
 
     #[options(help = "text to render")]
     pub text: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -273,6 +273,9 @@ pub struct ViewOpts {
     #[options(help = "language to shape", meta = "LANG")]
     pub lang: Option<String>,
 
+    #[options(help = "Annotate the origin of each glyph with a cross-hair", no_short)]
+    pub annotate: bool,
+
     #[options(help = "text to render")]
     pub text: Option<String>,
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -168,7 +168,7 @@ fn parse_features(features: &str) -> Features {
 impl From<&ViewOpts> for SVGMode {
     fn from(opts: &ViewOpts) -> Self {
         SVGMode::View {
-            annotate: opts.annotate,
+            mark_origin: opts.mark_origin,
         }
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -74,7 +74,7 @@ pub enum SVGMode {
     /// The String is the testcase name to be used as a prefix on ids.
     TextRenderingTests(String),
     /// SVGs are being generated for human viewing
-    View { annotate: bool },
+    View { mark_origin: bool },
 }
 
 pub struct SVGWriter {
@@ -245,7 +245,13 @@ impl SVGWriter {
     }
 
     fn annotate(&self) -> bool {
-        matches!(self.mode, SVGMode::View { annotate: true, .. })
+        matches!(
+            self.mode,
+            SVGMode::View {
+                mark_origin: true,
+                ..
+            }
+        )
     }
 }
 


### PR DESCRIPTION
Per #27 this PR add a `--annotate` option to the `view` command that adds a red cross-hair to the origin of each glyph. In the linked issue I think @n8willis was suggesting avoiding using colour but it seems like it needs to be a least a bit different to the colour of the glyphs so that if they overlap it's still visible, happy to discuss options/alternatives here.

Examples:

![ann](https://user-images.githubusercontent.com/21787/209034484-be7b1f1f-01dc-48bd-a1b8-a988de135125.svg)
![ann-en](https://user-images.githubusercontent.com/21787/209034491-cc4dad52-03bd-49b2-b96b-50f8361793cd.svg)
