### PR TITLE
Support for variable fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,9 @@ dependencies = [
 
 [[package]]
 name = "allsorts"
-version = "0.14.1"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b566d29776fc848a8279a72339499db95ee5592926bac114d35aa9a92efe9c"
 dependencies = [
  "bitflags",
  "bitreader",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,13 +47,12 @@ dependencies = [
 [[package]]
 name = "allsorts"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256467e8518f46b4ddbebd7cb8df2add04a720e3a6bdd0800c3896a5fc97ae3a"
 dependencies = [
  "bitflags",
  "bitreader",
  "brotli-decompressor",
  "byteorder",
+ "crc32fast",
  "encoding_rs",
  "flate2",
  "glyph-names",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ xmlwriter = "0.1.0"
 
 [dependencies.allsorts]
 version = "0.14.1"
+path = "../prince/src/fonts/allsorts"
 
 [dev-dependencies]
 assert_cmd = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ png = "0.15.3"
 xmlwriter = "0.1.0"
 
 [dependencies.allsorts]
-version = "0.14.1"
-path = "../prince/src/fonts/allsorts"
+version = "0.15.0"
 
 [dev-dependencies]
 assert_cmd = "1"

--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ Available tools:
 * [`cmap`](#cmap) — print character to glyph mappings
 * [`dump`](#dump) — dump font information
 * [`has-table`](#has-table) — check if a font has a particular table
+* [`instance`](#instance) — create a static instance of a font from a variable font
 * [`layout-features`](#layout-features) — print a list of a font's GSUB and GPOS features
 * [`shape`](#shape) — apply shaping to glyphs from a font
 * [`subset`](#subset) — subset a font
 * [`validate`](#validate) — parse the supplied font, reporting any failures
+* [`variations`](#variations) — list the variation axes of a variable font
 * [`view`](#view) — generate SVGs from glyphs
 
 ### `bitmaps`
@@ -179,6 +181,24 @@ is found the path to the font is printed.
 
     find . -regextype posix-extended -type f -iregex '.*\.(ttf|otf|otc)$' -exec allsorts has-table -t EBLC -p {} \;
 
+### `instance`
+
+The `instance` tool applies a set of values (tuple) to the variation axes of a
+variable font to produce a static, non-variable font with those settings.
+
+#### Options
+
+* `-t, --tuple` is a comma separated list of values one for each variation axis
+  of the font. The `variations` tool will list the axes, their order, and limits.
+* `-o, --output` is the path to the output font.
+
+#### Example
+
+In this example the font has two axes: `UNDO` and `UNDS`. We supply a value of
+500 for each one and write the output font to `UnderlineTest.ttf`.
+
+    allsorts --tuple 500,500 UnderlineTest-VF.ttf -o UnderlineTest.ttf
+
 ### `layout-features`
 
 Prints an indented list of a font's GSUB and GPOS features.
@@ -248,6 +268,59 @@ large repertoire of real world fonts.
 
     $ fd '\.(ttf|otf|ttc)$' /usr/share/fonts | sort | parallel --bar allsorts validate {}
 
+### `variations`
+
+The `variations` tool lists information about a variable font. The information
+includes:
+
+- The variation axes and their tag, minimum, maximum, and default values.
+- Any pre-defined instances and their name and axis values.
+
+#### Example
+
+This example prints variation information for the font at
+`../text-rendering-tests/fonts/TestHVARTwo.ttf`.
+
+    $ allsorts variations ../text-rendering-tests/fonts/TestHVARTwo.ttf
+    Axes: (2)
+
+    - wght = min: 0, max: 1000, default: 0
+    - cntr = min: 0, max: 100, default: 0
+
+    Instances:
+
+          Subfamily: ExtraLight
+    PostScript Name: TestFont-ExtraLight
+    Coordinates: [0.0, 0.0]
+
+          Subfamily: Light
+    PostScript Name: TestFont-Light
+    Coordinates: [150.0, 0.0]
+
+          Subfamily: Regular
+    PostScript Name: TestFont-Regular
+    Coordinates: [394.0, 0.0]
+
+          Subfamily: Semibold
+    PostScript Name: TestFont-Semibold
+    Coordinates: [600.0, 0.0]
+
+          Subfamily: Bold
+    PostScript Name: TestFont-Bold
+    Coordinates: [824.0, 0.0]
+
+          Subfamily: Black
+    PostScript Name: TestFont-Black
+    Coordinates: [1000.0, 0.0]
+
+          Subfamily: Black Medium Contrast
+    PostScript Name: TestFont-BlackMediumContrast
+    Coordinates: [1000.0, 50.0]
+
+          Subfamily: Black High Contrast
+    PostScript Name: TestFont-BlackHighContrast
+    Coordinates: [1000.0, 100.0]
+
 ### `view`
 
 The `view` tool shapes the supplied text or list of codepoints according to the
@@ -276,7 +349,7 @@ supplied font, language, and script. Then, it generates an SVG of the glyphs.
 
 #### Example Using Codepoints
 
-    $ view -f fonts/devanagari/NotoSerifDevanagari-Regular.ttf -s deva -c '916,93f'
+    $ allsorts view -f fonts/devanagari/NotoSerifDevanagari-Regular.ttf -s deva -c '916,93f'
     # output omitted
 
 #### Example Using Glyph Indices (and Features)

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ variable font to produce a static, non-variable font with those settings.
 In this example the font has two axes: `UNDO` and `UNDS`. We supply a value of
 500 for each one and write the output font to `UnderlineTest.ttf`.
 
-    allsorts --tuple 500,500 UnderlineTest-VF.ttf -o UnderlineTest.ttf
+    allsorts instance --tuple 500,500 UnderlineTest-VF.ttf -o UnderlineTest.ttf
 
 ### `layout-features`
 
@@ -273,7 +273,7 @@ large repertoire of real world fonts.
 The `variations` tool lists information about a variable font. The information
 includes:
 
-- The variation axes and their tag, minimum, maximum, and default values.
+- The variation axes with their tag, minimum, maximum, and default values.
 - Any pre-defined instances and their name and axis values.
 
 #### Example

--- a/src/bitmaps.rs
+++ b/src/bitmaps.rs
@@ -20,7 +20,7 @@ pub fn main(opts: BitmapOpts) -> Result<i32, BoxError> {
     let scope = ReadScope::new(&buffer);
     let font_file = scope.read::<FontData>()?;
     let table_provider = font_file.table_provider(opts.index)?;
-    let mut font = Font::new(table_provider)?.ok_or("unable to find suitable cmap sub-table")?;
+    let mut font = Font::new(table_provider)?;
 
     let output_path = Path::new(&opts.output);
     if !output_path.exists() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -275,6 +275,9 @@ pub struct SvgOpts {
     #[options(help = "name of test case", meta = "NAME", default = "allsorts")]
     pub testcase: String,
 
+    #[options(help = "variation settings for test case", meta = "AXES")]
+    pub variation: Option<String>,
+
     #[options(required, help = "text to render", meta = "TEXT")]
     pub render: String,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -175,7 +175,6 @@ pub struct InstanceOpts {
     )]
     pub index: usize,
 
-    // FIXME: better description
     // TODO: allow specifying the name of a STAT instance
     #[options(help = "comma-separated list of user-tuple values", meta = "TUPLE")]
     pub tuple: String,
@@ -227,6 +226,9 @@ pub struct ShapeOpts {
 
     #[options(free, required, help = "text to shape")]
     pub text: String,
+
+    #[options(help = "comma-separated list of user-tuple values", meta = "TUPLE")]
+    pub tuple: Option<String>,
 
     #[options(help = "vertical layout, default horizontal", no_short)]
     pub vertical: bool,
@@ -306,6 +308,9 @@ pub struct VariationsOpts {
     )]
     pub index: usize,
 
+    #[options(help = "output a HTML test file alongside the font")]
+    pub test: bool,
+
     #[options(free, required, help = "path to font file")]
     pub font: String,
 }
@@ -374,4 +379,7 @@ pub struct ViewOpts {
         meta = "FEATURES"
     )]
     pub features: Option<String>,
+
+    #[options(help = "comma-separated list of user-tuple values", meta = "TUPLE")]
+    pub tuple: Option<String>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,9 @@ pub enum Command {
     #[options(help = "check if a font has a particular table")]
     HasTable(HasTableOpts),
 
+    #[options(help = "create a static instance from a variable font")]
+    Instance(InstanceOpts),
+
     #[options(help = "print a list of a font's GSUB and GPOS features")]
     LayoutFeatures(LayoutFeaturesOpts),
 
@@ -158,6 +161,30 @@ pub struct HasTableOpts {
 
     #[options(free, required, help = "paths of fonts to check")]
     pub fonts: Vec<OsString>,
+}
+
+#[derive(Debug, Options)]
+pub struct InstanceOpts {
+    #[options(help = "print help message")]
+    pub help: bool,
+
+    #[options(
+        help = "index of the font to dump (for TTC, WOFF2)",
+        meta = "INDEX",
+        default = "0"
+    )]
+    pub index: usize,
+
+    // FIXME: better description
+    // TODO: allow specifying the name of a STAT instance
+    #[options(help = "comma-separated list of user-tuple values", meta = "TUPLE")]
+    pub tuple: String,
+
+    #[options(required, help = "path to destination font")]
+    pub output: String,
+
+    #[options(free, required, help = "path to input variable font file")]
+    pub font: String,
 }
 
 #[derive(Debug, Options)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,9 @@ pub enum Command {
     #[options(help = "parse the supplied font, reporting any failures")]
     Validate(ValidateOpts),
 
+    #[options(help = "print a list of a font's variations")]
+    Variations(VariationsOpts),
+
     #[options(help = "output an SVG rendition of the supplied text")]
     View(ViewOpts),
 }
@@ -258,6 +261,22 @@ pub struct ValidateOpts {
     pub help: bool,
 
     #[options(free, required, help = "path to font")]
+    pub font: String,
+}
+
+#[derive(Debug, Options)]
+pub struct VariationsOpts {
+    #[options(help = "print help message")]
+    pub help: bool,
+
+    #[options(
+        help = "index of the font to dump (for TTC, WOFF2)",
+        meta = "INDEX",
+        default = "0"
+    )]
+    pub index: usize,
+
+    #[options(free, required, help = "path to font file")]
     pub font: String,
 }
 

--- a/src/cmap.rs
+++ b/src/cmap.rs
@@ -14,13 +14,7 @@ pub fn main(opts: CmapOpts) -> Result<i32, BoxError> {
     let scope = ReadScope::new(&buffer);
     let font_file = scope.read::<FontData>()?;
     let table_provider = font_file.table_provider(opts.index)?;
-    let mut font = match Font::new(Box::new(table_provider))? {
-        Some(font) => font,
-        None => {
-            eprintln!("unable to find suitable cmap subtable");
-            return Ok(1);
-        }
-    };
+    let mut font = Font::new(Box::new(table_provider))?;
     dump_cmap(&mut font)?;
 
     Ok(0)

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -258,8 +258,8 @@ fn dump_woff2<'a>(
         ))?;
         let glyf = table.scope().read_dep::<Woff2GlyfTable>((entry, &loca))?;
 
-        println!("Read glyf table with {} glyphs:", glyf.records.len());
-        for glyph in glyf.records {
+        println!("Read glyf table with {} glyphs:", glyf.num_glyphs());
+        for glyph in glyf.records() {
             println!("- {:?}", glyph);
         }
     }
@@ -495,7 +495,7 @@ fn dump_glyph(provider: &impl FontTableProvider, glyph_id: u16) -> Result<(), Pa
     let glyf = scope.read_dep::<GlyfTable>(&loca)?;
 
     let mut glyph = glyf
-        .records
+        .records()
         .get(usize::from(glyph_id))
         .ok_or(ParseError::BadValue)?
         .clone();
@@ -517,32 +517,31 @@ fn dump_raw_table(scope: Option<ReadScope>) -> Result<(), BoxError> {
 
 fn get_name_meaning(name_id: u16) -> Option<&'static str> {
     match name_id {
-        0 => Some("Copyright"),
-        1 => Some("Font Family"),
-        2 => Some("Font Subfamily"),
-        3 => Some("Unique Identifier"),
-        4 => Some("Full Font Name"),
-        5 => Some("Version"),
-        6 => Some("PostScript Name"),
-        7 => Some("Trademark"),
-        8 => Some("Manufacturer"),
-        9 => Some("Designer"),
-        10 => Some("Description"),
-        11 => Some("URL Vendor"),
-        12 => Some("URL Designer"),
-        13 => Some("License Description"),
-        14 => Some("License Info URL"),
-        15 => None, // Reserved
-        16 => Some("Typographic Family"),
-        17 => Some("Typographic Subfamily"),
-        18 => Some("Compatible Full"),
-        19 => Some("Sample Text"),
-        20 => Some("PostScript CID findfont"),
-        21 => Some("WWS Family Name"),
-        22 => Some("WWS Subfamily Name"),
-        23 => Some("Light Background Palette"),
-        24 => Some("Dark Background Palette"),
-        25 => Some("Variations PostScript Name Prefix"),
+        NameTable::COPYRIGHT_NOTICE => Some("Copyright"),
+        NameTable::FONT_FAMILY_NAME => Some("Font Family"),
+        NameTable::FONT_SUBFAMILY_NAME => Some("Font Subfamily"),
+        NameTable::UNIQUE_FONT_IDENTIFIER => Some("Unique Identifier"),
+        NameTable::FULL_FONT_NAME => Some("Full Font Name"),
+        NameTable::VERSION_STRING => Some("Version"),
+        NameTable::POSTSCRIPT_NAME => Some("PostScript Name"),
+        NameTable::TRADEMARK => Some("Trademark"),
+        NameTable::MANUFACTURER_NAME => Some("Manufacturer"),
+        NameTable::DESIGNER => Some("Designer"),
+        NameTable::DESCRIPTION => Some("Description"),
+        NameTable::URL_VENDOR => Some("URL Vendor"),
+        NameTable::URL_DESIGNER => Some("URL Designer"),
+        NameTable::LICENSE_DESCRIPTION => Some("License Description"),
+        NameTable::LICENSE_INFO_URL => Some("License Info URL"),
+        NameTable::TYPOGRAPHIC_FAMILY_NAME => Some("Typographic Family"),
+        NameTable::TYPOGRAPHIC_SUBFAMILY_NAME => Some("Typographic Subfamily"),
+        NameTable::COMPATIBLE_FULL => Some("Compatible Full"),
+        NameTable::SAMPLE_TEXT => Some("Sample Text"),
+        NameTable::POSTSCRIPT_CID_FINDFONT_NAME => Some("PostScript CID findfont"),
+        NameTable::WWS_FAMILY_NAME => Some("WWS Family Name"),
+        NameTable::WWS_SUBFAMILY_NAME => Some("WWS Subfamily Name"),
+        NameTable::LIGHT_BACKGROUND_PALETTE => Some("Light Background Palette"),
+        NameTable::DARK_BACKGROUND_PALETTE => Some("Dark Background Palette"),
+        NameTable::VARIATIONS_POSTSCRIPT_NAME_PREFIX => Some("Variations PostScript Name Prefix"),
         _ => None,
     }
 }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -3,7 +3,7 @@ use std::convert::{self, TryFrom};
 use std::io::{self, IsTerminal, Write};
 use std::str;
 
-use encoding_rs::{Encoding, MACINTOSH, UTF_16BE};
+use encoding_rs::{MACINTOSH, UTF_16BE};
 
 use allsorts::binary::read::ReadScope;
 use allsorts::cff::{self, CFFVariant, Charset, FontDict, Operator, CFF};
@@ -23,7 +23,7 @@ use allsorts::woff::WoffFont;
 use allsorts::woff2::{Woff2Font, Woff2GlyfTable, Woff2LocaTable};
 
 use crate::cli::DumpOpts;
-use crate::{BoxError, ErrorMessage};
+use crate::{decode, BoxError, ErrorMessage};
 
 type Tag = u32;
 
@@ -305,6 +305,17 @@ fn dump_name_table(name_table: &NameTable) -> Result<(), ParseError> {
         println!();
     }
 
+    if let Some(langtag_records) = &name_table.opt_langtag_records {
+        for langtag in langtag_records.iter() {
+            let name_data = name_table
+                .string_storage
+                .offset_length(langtag.offset.into(), langtag.length.into())?
+                .data();
+            let name = decode(UTF_16BE, name_data);
+            println!("langtag {}", name);
+        }
+    }
+
     Ok(())
 }
 
@@ -501,17 +512,6 @@ fn dump_raw_table(scope: Option<ReadScope>) -> Result<(), BoxError> {
             .map_err(|err| err.into())
     } else {
         Err(ErrorMessage("Table not found").into())
-    }
-}
-
-fn decode(encoding: &'static Encoding, data: &[u8]) -> String {
-    let mut decoder = encoding.new_decoder();
-    if let Some(size) = decoder.max_utf8_buffer_length(data.len()) {
-        let mut s = String::with_capacity(size);
-        let (_res, _read, _repl) = decoder.decode_to_string(data, &mut s, true);
-        s
-    } else {
-        String::new() // can only happen if buffer is enormous
     }
 }
 

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -1,5 +1,5 @@
 use allsorts::error::ParseError;
-use allsorts::gsub::{GlyphOrigin, RawGlyph};
+use allsorts::gsub::{GlyphOrigin, RawGlyph, RawGlyphFlags};
 use allsorts::tables::cmap::CmapSubtable;
 use allsorts::tinyvec::tiny_vec;
 use allsorts::unicode::VariationSelector;
@@ -27,12 +27,8 @@ pub(crate) fn make(
         glyph_index,
         liga_component_pos: 0,
         glyph_origin: GlyphOrigin::Char(ch),
-        small_caps: false,
-        multi_subst_dup: false,
-        is_vert_alt: false,
-        fake_bold: false,
-        fake_italic: false,
-        extra_data: (),
+        flags: RawGlyphFlags::empty(),
         variation,
+        extra_data: (),
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,0 +1,24 @@
+use std::fs::File;
+use std::io::Write;
+
+use allsorts::binary::read::ReadScope;
+use allsorts::font_data::FontData;
+
+use crate::cli::InstanceOpts;
+use crate::{parse_tuple, BoxError};
+
+pub fn main(opts: InstanceOpts) -> Result<i32, BoxError> {
+    let buffer = std::fs::read(&opts.font)?;
+    let scope = ReadScope::new(&buffer);
+    let font_file = scope.read::<FontData>()?;
+    let provider = font_file.table_provider(opts.index)?;
+
+    let user_instance = parse_tuple(&opts.tuple)?;
+    let (new_font, _tuple) = allsorts::variations::instance(&provider, &user_instance)?;
+
+    // Write out the new font
+    let mut output = File::create(&opts.output)?;
+    output.write_all(&new_font)?;
+
+    Ok(0)
+}

--- a/src/layout_features.rs
+++ b/src/layout_features.rs
@@ -12,13 +12,7 @@ pub fn main(opts: LayoutFeaturesOpts) -> Result<i32, BoxError> {
     let scope = ReadScope::new(&buffer);
     let font_file = scope.read::<FontData>()?;
     let provider = font_file.table_provider(opts.index)?;
-    let mut font = match Font::new(provider)? {
-        Some(font) => font,
-        None => {
-            eprintln!("unable to find suitable cmap subtable");
-            return Ok(1);
-        }
-    };
+    let mut font = Font::new(provider)?;
 
     if let Some(gsub_cache) = font.gsub_cache()? {
         println!("Table: GSUB");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,14 @@ pub mod shape;
 pub mod subset;
 pub mod svg;
 pub mod validate;
+pub mod variations;
 pub mod view;
 mod writer;
 
 use std::error::Error;
 use std::fmt;
+
+use encoding_rs::Encoding;
 
 pub type BoxError = Box<dyn Error>;
 
@@ -28,3 +31,15 @@ impl fmt::Display for ErrorMessage {
 }
 
 impl Error for ErrorMessage {}
+
+/// Decode a non-utf-8 string to a UTF-8 Rust string.
+pub(crate) fn decode(encoding: &'static Encoding, data: &[u8]) -> String {
+    let mut decoder = encoding.new_decoder();
+    if let Some(size) = decoder.max_utf8_buffer_length(data.len()) {
+        let mut s = String::with_capacity(size);
+        let (_res, _read, _repl) = decoder.decode_to_string(data, &mut s, true);
+        s
+    } else {
+        String::new() // can only happen if buffer is enormous
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ impl fmt::Display for ErrorMessage {
 
 impl Error for ErrorMessage {}
 
-/// Decode a non-utf-8 string to a UTF-8 Rust string.
+/// Decode a non-UTF-8 string to a UTF-8 Rust string.
 pub(crate) fn decode(encoding: &'static Encoding, data: &[u8]) -> String {
     let mut decoder = encoding.new_decoder();
     if let Some(size) = decoder.max_utf8_buffer_length(data.len()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cmap;
 pub mod dump;
 mod glyph;
 pub mod has_table;
+pub mod instance;
 pub mod layout_features;
 mod script;
 pub mod shape;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ use std::{env, process};
 
 use allsorts_tools::cli::*;
 use allsorts_tools::{
-    bitmaps, cmap, dump, has_table, layout_features, shape, subset, svg, validate, variations,
-    view, BoxError,
+    bitmaps, cmap, dump, has_table, instance, layout_features, shape, subset, svg, validate,
+    variations, view, BoxError,
 };
 use gumdrop::Options;
 
@@ -35,6 +35,7 @@ fn allsorts_main() -> Result<i32, BoxError> {
         Some(Command::Cmap(opts)) => cmap::main(opts),
         Some(Command::Dump(opts)) => dump::main(opts),
         Some(Command::HasTable(opts)) => has_table::main(opts),
+        Some(Command::Instance(opts)) => instance::main(opts),
         Some(Command::LayoutFeatures(opts)) => layout_features::main(opts),
         Some(Command::Shape(opts)) => shape::main(opts),
         Some(Command::Subset(opts)) => subset::main(opts),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@ use std::{env, process};
 
 use allsorts_tools::cli::*;
 use allsorts_tools::{
-    bitmaps, cmap, dump, has_table, layout_features, shape, subset, svg, validate, view, BoxError,
+    bitmaps, cmap, dump, has_table, layout_features, shape, subset, svg, validate, variations,
+    view, BoxError,
 };
 use gumdrop::Options;
 
@@ -39,6 +40,7 @@ fn allsorts_main() -> Result<i32, BoxError> {
         Some(Command::Subset(opts)) => subset::main(opts),
         Some(Command::Svg(opts)) => svg::main(opts),
         Some(Command::Validate(opts)) => validate::main(opts),
+        Some(Command::Variations(opts)) => variations::main(opts),
         Some(Command::View(opts)) => view::main(opts),
         None => usage(),
     }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -29,13 +29,7 @@ pub fn main(opts: ShapeOpts) -> Result<i32, BoxError> {
         None => None,
     };
 
-    let mut font = match Font::new(Box::new(provider))? {
-        Some(font) => font,
-        None => {
-            eprintln!("unable to find suitable cmap subtable");
-            return Ok(1);
-        }
-    };
+    let mut font = Font::new(Box::new(provider))?;
     let glyphs = font.map_glyphs(&opts.text, script, MatchingPresentation::NotRequired);
     let infos = font
         .shape(

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -6,7 +6,7 @@ use std::str;
 use allsorts::binary::read::ReadScope;
 use allsorts::font::read_cmap_subtable;
 use allsorts::font_data::FontData;
-use allsorts::gsub::{GlyphOrigin, RawGlyph};
+use allsorts::gsub::{GlyphOrigin, RawGlyph, RawGlyphFlags};
 use allsorts::tables::cmap::Cmap;
 use allsorts::tables::{FontTableProvider, MaxpTable};
 use allsorts::tinyvec::tiny_vec;
@@ -61,13 +61,9 @@ fn subset_text<F: FontTableProvider>(
         glyph_index: 0,
         liga_component_pos: 0,
         glyph_origin: GlyphOrigin::Direct,
-        small_caps: false,
-        multi_subst_dup: false,
-        is_vert_alt: false,
-        fake_bold: false,
-        fake_italic: false,
-        extra_data: (),
+        flags: RawGlyphFlags::empty(),
         variation: None,
+        extra_data: (),
     };
     glyphs.insert(0, Some(notdef));
 

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -35,13 +35,7 @@ pub fn main(opts: SvgOpts) -> Result<i32, BoxError> {
     let provider = font_file.table_provider(0)?;
 
     // Map text to glyphs and then apply font shaping
-    let mut font = match Font::new(provider)? {
-        Some(font) => font,
-        None => {
-            eprintln!("unable to find suitable cmap subtable");
-            return Ok(1);
-        }
-    };
+    let mut font = Font::new(provider)?;
     let glyphs = font.map_glyphs(&opts.render, script, MatchingPresentation::NotRequired);
     let infos = font
         .shape(

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -56,7 +56,7 @@ fn dump_glyphs(path: &str, provider: &impl FontTableProvider) -> Result<bool, Pa
         let scope = ReadScope::new(table.borrow());
         let mut glyf = scope.read_dep::<GlyfTable>(&loca)?;
 
-        for (index, glyph) in glyf.records.iter_mut().enumerate() {
+        for (index, glyph) in glyf.records_mut().iter_mut().enumerate() {
             match glyph.parse() {
                 Ok(()) => (),
                 Err(err) => {

--- a/src/variations.rs
+++ b/src/variations.rs
@@ -100,8 +100,12 @@ fn print_variations(provider: &impl FontTableProvider) -> Result<(), BoxError> {
 }
 
 fn generate_test(provider: &DynamicFontTableProvider, font: &str) -> Result<(), BoxError> {
-    if !(provider.has_table(tag::FVAR) && provider.has_table(tag::GVAR)) {
-        println!("Font does have both fvar and gvar");
+    if !provider.has_table(tag::FVAR) {
+        println!("Font does have fvar");
+        return Ok(());
+    }
+    if !(provider.has_table(tag::CFF2) || provider.has_table(tag::GVAR)) {
+        println!("Font does have gvar or CFF2");
         return Ok(());
     }
 

--- a/src/variations.rs
+++ b/src/variations.rs
@@ -1,0 +1,117 @@
+use allsorts::binary::read::ReadScope;
+use allsorts::font_data::FontData;
+use allsorts::tables::variable_fonts::fvar::FvarTable;
+use allsorts::tables::{FontTableProvider, NameTable};
+use allsorts::tag;
+use allsorts::tag::DisplayTag;
+use encoding_rs::{MACINTOSH, UTF_16BE};
+
+use crate::cli::VariationsOpts;
+use crate::BoxError;
+
+pub fn main(opts: VariationsOpts) -> Result<i32, BoxError> {
+    let buffer = std::fs::read(&opts.font)?;
+    let scope = ReadScope::new(&buffer);
+    let font_file = scope.read::<FontData>()?;
+    let provider = font_file.table_provider(opts.index)?;
+    print_variations(&provider)?;
+
+    Ok(0)
+}
+
+fn print_variations(provider: &impl FontTableProvider) -> Result<(), BoxError> {
+    let Some(table) = provider.table_data(tag::FVAR)? else {
+        println!("Font does not appear to be a variable font (no fvar table found)");
+        return Ok(());
+    };
+    let scope = ReadScope::new(&table);
+    let fvar = scope.read::<FvarTable>()?;
+
+    let name_table_data = provider.table_data(tag::NAME)?;
+    let name_table = name_table_data
+        .as_ref()
+        .map(|data| ReadScope::new(data).read::<NameTable>())
+        .transpose()?;
+
+    println!("Axes: ({})\n", fvar.axes().count());
+    for axis in fvar.axes() {
+        let axis = axis?;
+        println!(
+            "- {} = min: {}, max: {}, default: {}",
+            DisplayTag(axis.axis_tag),
+            f32::from(axis.min_value),
+            f32::from(axis.max_value),
+            f32::from(axis.default_value)
+        )
+    }
+    println!("\nInstances:");
+    for instance in fvar.instances() {
+        let instance = instance?;
+        let subfamily = english_name_for_name_id(&name_table, instance.subfamily_name_id);
+        let postscript_name = instance
+            .post_script_name_id
+            .and_then(|name_id| english_name_for_name_id(&name_table, name_id));
+
+        println!(
+            "\n      Subfamily: {}",
+            subfamily.as_deref().unwrap_or("Unknown"),
+        );
+        if instance.post_script_name_id.is_some() {
+            println!(
+                "PostScript Name: {}",
+                postscript_name.as_deref().unwrap_or("Unknown")
+            );
+        }
+        println!(
+            "    Coordinates: {:?}",
+            instance
+                .coordinates
+                .iter()
+                .map(f32::from)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    Ok(())
+}
+
+fn english_name_for_name_id(name_table: &Option<NameTable>, name_id: u16) -> Option<String> {
+    name_table.as_ref().and_then(|name_table| {
+        name_table
+            .name_records
+            .iter()
+            .find_map(|record| {
+                if record.name_id != name_id {
+                    return None;
+                }
+                // Match English records
+                match (record.platform_id, record.encoding_id, record.language_id) {
+                    (0, _, _) => Some((record, UTF_16BE)),
+                    (1, 0, 0) => Some((record, MACINTOSH)),
+                    (
+                        3,
+                        1,
+                        0x0C09 | 0x2809 | 0x1009 | 0x2409 | 0x4009 | 0x1809 | 0x2009 | 0x4409
+                        | 0x1409 | 0x3409 | 0x4809 | 0x1C09 | 0x2C09 | 0x0809 | 0x0409 | 0x3009,
+                    ) => Some((record, UTF_16BE)),
+                    (
+                        3,
+                        10,
+                        0x0C09 | 0x2809 | 0x1009 | 0x2409 | 0x4009 | 0x1809 | 0x2009 | 0x4409
+                        | 0x1409 | 0x3409 | 0x4809 | 0x1C09 | 0x2C09 | 0x0809 | 0x0409 | 0x3009,
+                    ) => Some((record, UTF_16BE)),
+                    _ => None,
+                }
+            })
+            .and_then(|(record, encoding)| {
+                let offset = usize::from(record.offset);
+                let length = usize::from(record.length);
+                let name_data = name_table
+                    .string_storage
+                    .offset_length(offset, length)
+                    .ok()?
+                    .data();
+                Some(crate::decode(encoding, name_data))
+            })
+    })
+}

--- a/src/view.rs
+++ b/src/view.rs
@@ -3,7 +3,7 @@ use allsorts::cff::CFF;
 use allsorts::error::ParseError;
 use allsorts::font::{Font, GlyphTableFlags, MatchingPresentation};
 use allsorts::font_data::FontData;
-use allsorts::gsub::{FeatureInfo, FeatureMask, Features, GlyphOrigin, RawGlyph};
+use allsorts::gsub::{FeatureInfo, FeatureMask, Features, GlyphOrigin, RawGlyph, RawGlyphFlags};
 use allsorts::pathfinder_geometry::transform2d::Matrix2x2F;
 use allsorts::pathfinder_geometry::vector::vec2f;
 use allsorts::post::PostTable;
@@ -58,13 +58,7 @@ pub fn main(opts: ViewOpts) -> Result<i32, BoxError> {
         None => None,
     };
 
-    let mut font = match Font::new(provider)? {
-        Some(font) => font,
-        None => {
-            eprintln!("unable to find suitable cmap subtable");
-            return Ok(1);
-        }
-    };
+    let mut font = Font::new(provider)?;
 
     let glyphs = if let Some(ref text) = opts.text {
         font.map_glyphs(&text, script, MatchingPresentation::NotRequired)
@@ -163,11 +157,7 @@ fn make_raw_glyph(glyph_index: u16) -> RawGlyph<()> {
         glyph_index,
         liga_component_pos: 0,
         glyph_origin: GlyphOrigin::Char('x'),
-        small_caps: false,
-        multi_subst_dup: false,
-        is_vert_alt: false,
-        fake_bold: false,
-        fake_italic: false,
+        flags: RawGlyphFlags::empty(),
         variation: None,
         extra_data: (),
     }

--- a/src/view.rs
+++ b/src/view.rs
@@ -15,7 +15,7 @@ use allsorts::tag;
 use allsorts::tinyvec::tiny_vec;
 
 use crate::cli::ViewOpts;
-use crate::writer::{GlyfPost, SVGMode, SVGWriter};
+use crate::writer::{NamedOutliner, SVGMode, SVGWriter};
 use crate::BoxError;
 use crate::{normalise_tuple, parse_tuple, script};
 
@@ -117,7 +117,7 @@ pub fn main(opts: ViewOpts) -> Result<i32, BoxError> {
             .as_ref()
             .map(|data| ReadScope::new(data).read::<PostTable<'_>>())
             .transpose()?;
-        let mut glyf_post = GlyfPost { glyf, post };
+        let mut glyf_post = NamedOutliner { table: glyf, post };
         let writer = SVGWriter::new(mode, transform);
         writer.glyphs_to_svg(&mut glyf_post, &mut font, &infos, direction)?
     } else {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -488,19 +488,19 @@ impl<'info> Symbol<'info> {
                         GlyphOrigin::Direct => String::from("direct"),
                     },
                 );
-                if self.info.glyph.small_caps {
+                if self.info.glyph.small_caps() {
                     data.insert("data-small-caps", bool_true.clone());
                 }
-                if self.info.glyph.multi_subst_dup {
+                if self.info.glyph.multi_subst_dup() {
                     data.insert("data-multi-subst-dup", bool_true.clone());
                 }
-                if self.info.glyph.is_vert_alt {
+                if self.info.glyph.is_vert_alt() {
                     data.insert("data-is-vert-alt", bool_true.clone());
                 }
-                if self.info.glyph.fake_bold {
+                if self.info.glyph.fake_bold() {
                     data.insert("data-fake-bold", bool_true.clone());
                 }
-                if self.info.glyph.fake_italic {
+                if self.info.glyph.fake_italic() {
                     data.insert("data-fake-italic", bool_true.clone());
                 }
                 data

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -150,7 +150,7 @@ impl<'a> GlyphName for CFF<'a> {
             return None;
         }
         let sid = font.charset.id_for_glyph(glyph_id)?;
-        self.read_string(sid).ok()
+        self.read_string(sid).map(ToString::to_string).ok()
     }
 }
 
@@ -159,7 +159,7 @@ impl<'a> GlyphName for GlyfPost<'a> {
         self.post
             .as_ref()
             .and_then(|post| post.glyph_name(glyph_id).ok().flatten())
-            .map(|s| s.to_string())
+            .map(ToString::to_string)
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7,9 +7,23 @@ use predicates::prelude::*;
 fn dump_glyph() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("allsorts")?;
     cmd.args(&["dump", "-g", "1", "tests/Basic-Regular.ttf"]);
-    cmd.assert().success().stdout(predicate::str::starts_with(
-        "Parsed(\n    Glyph {\n        number_of_contours: 3,",
-    ));
+    let expected = r#"Parsed(
+    Simple(
+        SimpleGlyph {
+            bounding_box: BoundingBox {
+                x_min: 158,
+                x_max: 1082,
+                y_min: 0,
+                y_max: 1358,
+            },
+            end_pts_of_contours: [
+                22,
+                35,
+                44,
+            ],"#;
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::starts_with(expected));
 
     Ok(())
 }
@@ -19,7 +33,15 @@ fn dump_empty_glyph() -> Result<(), Box<dyn std::error::Error>> {
     // Glyph 112 is .null
     let mut cmd = Command::cargo_bin("allsorts")?;
     cmd.args(&["dump", "-g", "112", "tests/Basic-Regular.ttf"]);
-    cmd.assert().success().stdout("Empty\n");
+    let expected = r#"Parsed(
+    Empty(
+        EmptyGlyph {
+            phantom_points: None,
+        },
+    ),
+)
+"#;
+    cmd.assert().success().stdout(expected);
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds two new sub-commands related to variable fonts:

1. `instance` for creating a non-variable instance of a variable font
2. `variations` for listing variation information about a variable font such as axes and pre-defined instances.

Additionally support for CFF2 is added. The `svg` sub-command used by the unicode-text-rendering tests was also updated to support variable fonts and CFF2.