### PR TITLE
Replace atty with is_terminal from std lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        rust: [stable, 1.66.0]
+        rust: [stable, 1.70.0]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,6 @@ version = "0.11.0"
 dependencies = [
  "allsorts",
  "assert_cmd",
- "atty",
  "encoding_rs",
  "gumdrop",
  "png",
@@ -98,17 +97,6 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -270,15 +258,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "inflate"
@@ -657,28 +636,6 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xmlwriter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ name = "allsorts"
 path = "src/main.rs"
 
 [dependencies]
-atty = "0.2.13"
 encoding_rs = "0.8.16"
 gumdrop = "0.7.0"
 png = "0.15.3"

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ to be replaced by its special presentation form (glyph 547).
 
 ### From Source
 
-**Minimum Supported Rust Version:** Same as Allsorts
+**Minimum Supported Rust Version:** 1.70.0
 
 To build the tools ensure you have [Rust installed](https://www.rust-lang.org/tools/install).
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,9 +1,8 @@
 use std::borrow::Borrow;
 use std::convert::{self, TryFrom};
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::str;
 
-use atty::Stream;
 use encoding_rs::{Encoding, MACINTOSH, UTF_16BE};
 
 use allsorts::binary::read::ReadScope;
@@ -41,7 +40,7 @@ pub fn main(opts: DumpOpts) -> Result<i32, BoxError> {
         .table
         .map(|table| tag::from_string(&table))
         .transpose()?;
-    if table.is_some() && atty::is(Stream::Stdout) {
+    if table.is_some() && io::stdout().is_terminal() {
         return Err(ErrorMessage("Not printing binary data to tty.").into());
     }
 


### PR DESCRIPTION
This deals with https://rustsec.org/advisories/RUSTSEC-2021-0145.html by replacing atty with `is_terminal` from the standard library.

This requires bumping MSRV up to 1.70.0, which is the first version `is_terminal` was stable.
