### PR TITLE
Font specimen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,11 @@ dependencies = [
  "rustc-hash",
  "tinyvec",
  "ucd-trie",
+ "unicode-blocks",
  "unicode-canonical-combining-class",
  "unicode-general-category",
  "unicode-joining-type",
+ "upon",
 ]
 
 [[package]]
@@ -594,6 +596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "unicode-blocks"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
+
+[[package]]
 name = "unicode-canonical-combining-class"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +624,12 @@ name = "unicode-joining-type"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f8cb47ccb8bc750808755af3071da4a10dcd147b68fc874b7ae4b12543f6f5"
+
+[[package]]
+name = "upon"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe29601d1624f104fa9a35ea71a5f523dd8bd1cfc8c31f8124ad2b829f013c0"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ xmlwriter = "0.1.0"
 
 [dependencies.allsorts]
 version = "0.15.0"
+features = ["specimen"]
 
 [dev-dependencies]
 assert_cmd = "1"

--- a/README.md
+++ b/README.md
@@ -171,8 +171,10 @@ This tool is handy combined with `find`, to locate fonts that have the desired t
 
 #### Options
 
-* `-p` makes the tool print the path to the font if it contains the
-  table.
+* `-t`, `--table TABLE` table to check for
+* `-i`, `--index INDEX` index of the font to check (for TTC, WOFF2) (default: 0)
+* `-p`, `--print-file` print the path to the font if it contains the table.
+* `-v`, `--invert-match` select fonts that don't have the given table
 
 #### Example
 
@@ -189,9 +191,9 @@ variable font to produce a static, non-variable font with those settings.
 
 #### Options
 
-* `-t, --tuple` is a comma separated list of values one for each variation axis
+* `-t`, `--tuple` is a comma separated list of values one for each variation axis
   of the font. The `variations` tool will list the axes, their order, and limits.
-* `-o, --output` is the path to the output font.
+* `-o`, `--output` is the path to the output font.
 
 #### Example
 
@@ -259,9 +261,9 @@ the source font only containing the glyphs required for the supplied text.
 
 #### Options
 
-`-t`, `--text TEXT` subset the font to include glyphs from TEXT
-`-a`, `--all` include all glyphs in the subset font
-`-i`, `--index INDEX` index of the font to subset (for TTC, WOFF2) (default: 0)
+* `-t`, `--text TEXT` subset the font to include glyphs from TEXT
+* `-a`, `--all` include all glyphs in the subset font
+* `-i`, `--index INDEX` index of the font to subset (for TTC, WOFF2) (default: 0)
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Available tools:
 * [`instance`](#instance) — create a static instance of a font from a variable font
 * [`layout-features`](#layout-features) — print a list of a font's GSUB and GPOS features
 * [`shape`](#shape) — apply shaping to glyphs from a font
+* [`specimen`](#specimen) — generate a HTML font speciment for a font
 * [`subset`](#subset) — subset a font
 * [`validate`](#validate) — parse the supplied font, reporting any failures
 * [`variations`](#variations) — list the variation axes of a variable font
@@ -236,6 +237,20 @@ script. It prints out the glyphs before and after shaping.
 
     $ shape -f fonts/devanagari/AnnapurnaSIL-Regular.ttf -s deva -l HIN 'शब्दों और वाक्यों की तरह'
     # output omitted
+
+### `specimen`
+
+The `specimen` tool generates a HTML font specimen sheet containing sample text
+set in the font as well as information about the font and its supported features.
+
+#### Options
+
+* `-i`, `--index INDEX` index of the font to subset (for TTC, WOFF2) (default: 0)
+* `--sample-text TEXT` sample text to use in the font specimen
+
+#### Example
+
+    $ allsorts specimen ../allsorts/tests/fonts/bengali/Lohit-Bengali.ttf
 
 ### `subset`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,9 @@ pub enum Command {
     #[options(help = "apply shaping to glyphs from a font")]
     Shape(ShapeOpts),
 
+    #[options(help = "generate a specimen page for a font")]
+    Specimen(SpecimenOpts),
+
     #[options(help = "subset a font")]
     Subset(SubsetOpts),
 
@@ -232,6 +235,29 @@ pub struct ShapeOpts {
 
     #[options(help = "vertical layout, default horizontal", no_short)]
     pub vertical: bool,
+}
+
+#[derive(Debug, Options)]
+pub struct SpecimenOpts {
+    #[options(help = "print help message")]
+    pub help: bool,
+
+    #[options(
+        help = "index of the font to read (for TTC, WOFF2)",
+        meta = "INDEX",
+        default = "0"
+    )]
+    pub index: u32,
+
+    #[options(
+        no_short,
+        help = "sample text to use in the font specimen",
+        meta = "TEXT"
+    )]
+    pub sample_text: Option<String>,
+
+    #[options(free, required, help = "path to font file")]
+    pub font: String,
 }
 
 #[derive(Debug, Options)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod instance;
 pub mod layout_features;
 mod script;
 pub mod shape;
+pub mod specimen;
 pub mod subset;
 pub mod svg;
 pub mod validate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ use std::{env, process};
 
 use allsorts_tools::cli::*;
 use allsorts_tools::{
-    bitmaps, cmap, dump, has_table, instance, layout_features, shape, subset, svg, validate,
-    variations, view, BoxError,
+    bitmaps, cmap, dump, has_table, instance, layout_features, shape, specimen, subset, svg,
+    validate, variations, view, BoxError,
 };
 use gumdrop::Options;
 
@@ -38,6 +38,7 @@ fn allsorts_main() -> Result<i32, BoxError> {
         Some(Command::Instance(opts)) => instance::main(opts),
         Some(Command::LayoutFeatures(opts)) => layout_features::main(opts),
         Some(Command::Shape(opts)) => shape::main(opts),
+        Some(Command::Specimen(opts)) => specimen::main(opts),
         Some(Command::Subset(opts)) => subset::main(opts),
         Some(Command::Svg(opts)) => svg::main(opts),
         Some(Command::Validate(opts)) => validate::main(opts),

--- a/src/specimen.rs
+++ b/src/specimen.rs
@@ -1,0 +1,33 @@
+use std::fs;
+
+use allsorts::font_specimen::{self, SpecimenOptions};
+
+use crate::cli::SpecimenOpts;
+use crate::BoxError;
+
+pub fn main(opts: SpecimenOpts) -> Result<i32, BoxError> {
+    let specimen_options = SpecimenOptions {
+        index: opts.index,
+        sample_text: opts.sample_text,
+    };
+    let font_data = fs::read(&opts.font)?;
+    let (head, body) = font_specimen::specimen(&opts.font, &font_data, specimen_options)?;
+
+    println!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+    {head}
+</head>
+<body>
+    {body}
+    <footer style="text-align: center">
+        <img src="https://github.com/yeslogic/allsorts/raw/master/allsorts.svg?sanitize=1" width="32" style="vertical-align: middle" alt="">
+        Generated with <a href="https://github.com/yeslogic/allsorts-tools">Allsorts</a>.
+    </footer>
+</body>
+</html>"#
+    );
+
+    Ok(0)
+}


### PR DESCRIPTION
This PR adds a new `speciment` sub-command that uses Allsorts new font specimen functionality to generate a HTML font specimen page. Depends on #38 