### PR TITLE
view: Cycle through multiple fg colours if supplied

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -367,10 +367,10 @@ pub struct ViewOpts {
 
     #[options(
         help = "set the fill colour of the glyphs",
-        meta = "rrggbbaa",
+        meta = "rrggbbaa...",
         no_short
     )]
-    pub fg_colour: Option<Colour>,
+    pub fg_colour: Vec<Colour>,
 
     #[options(
         help = "set the background colour of the generated SVG",
@@ -379,8 +379,8 @@ pub struct ViewOpts {
     )]
     pub bg_colour: Option<Colour>,
 
-    #[options(help = "alias for --fg-colour", meta = "rrggbbaa", no_short)]
-    pub fg_color: Option<Colour>,
+    #[options(help = "alias for --fg-colour", meta = "rrggbbaa...", no_short)]
+    pub fg_color: Vec<Colour>,
 
     #[options(help = "alias for --bg-colour", meta = "rrggbbaa", no_short)]
     pub bg_color: Option<Colour>,

--- a/src/view.rs
+++ b/src/view.rs
@@ -178,10 +178,15 @@ fn parse_features(features: &str) -> Features {
 
 impl From<&ViewOpts> for SVGMode {
     fn from(opts: &ViewOpts) -> Self {
+        let fg = if opts.fg_colour.is_empty() {
+            &opts.fg_color
+        } else {
+            &opts.fg_colour
+        };
         SVGMode::View {
             mark_origin: opts.mark_origin,
             margin: opts.margin.unwrap_or_default(),
-            fg: opts.fg_colour.or(opts.fg_color),
+            fg: fg.clone(),
             bg: opts.bg_colour.or(opts.bg_color),
         }
     }


### PR DESCRIPTION
Closes #41 

@n8willis had a go at implementing #41 here's some sample output:

```
allsorts view -f ../prince/tests/data/fonts/morx/Zapfino.ttf -t 'Zapfino'\!'' -s LATN --features kern,mark,mkmk,liga --fg-colour ff0000aa --fg-colour 00ff00aa --fg-colour 0000ffaa
```

![Zapfino](https://github.com/user-attachments/assets/b800f88c-dfcf-4d7e-b35b-7018dbaf5ee2)

```
allsorts view -f /home/wmoore/Downloads/lanna-export-pdf-issue/LN_TILOK_V6_05.woff -s thai -t 'เวรญชฯกณฑ' --features kern,mark,mkmk,liga --fg-colour ff0000aa --fg-colour 00ff00aa --fg-colour 0000ffaa
```

![master](https://github.com/user-attachments/assets/37622dc2-2aba-40e7-9e40-47b01ec2b577)

**Note:** there's an invisible/zero-width glyph in this one, which is why it skips the second use of blue.